### PR TITLE
Add device configuration backup and restore functionality

### DIFF
--- a/build_info.h
+++ b/build_info.h
@@ -9,8 +9,8 @@
 #define BUILD_TIME __TIME__
 
 // Git information (updated by compile script)
-#define GIT_COMMIT_HASH "8845feb"
-#define GIT_COMMIT_FULL "8845feb8cfedc9e828d4ac05d499daeab1c3773e"
-#define GIT_BRANCH "feat/solar-lunar-display"
+#define GIT_COMMIT_HASH "1f1abd5"
+#define GIT_COMMIT_FULL "1f1abd5bdb01707a96e570f90a548c52461d36c0"
+#define GIT_BRANCH "snd"
 
 #endif // BUILD_INFO_H

--- a/config.h
+++ b/config.h
@@ -23,6 +23,11 @@ enum LogSeverity {
 // SYSTEM CONFIGURATION
 // =============================================================================
 
+// Config backup/restore schema version. Bump when fields are added, renamed,
+// removed, or change meaning. See config_backup.cpp migrate() for the
+// non-additive migration hook.
+#define CONFIG_SCHEMA_VERSION 1
+
 // Memory allocation sizes
 // NOTE: These values automatically control PPA hardware accelerator buffer sizes:
 //   - PPA source buffer = FULL_IMAGE_BUFFER_SIZE

--- a/config_backup.cpp
+++ b/config_backup.cpp
@@ -1,0 +1,380 @@
+#include "config_backup.h"
+#include "config_storage.h"
+#include "config.h"
+#include "build_info.h"
+#include <ArduinoJson.h>
+
+// This file owns the single source of truth for the backup field list. The
+// export and import key lists below are kept adjacent so they stay in sync.
+// Any change to ConfigStorage fields should be reflected in BOTH lists and the
+// CONFIG_SCHEMA_VERSION constant bumped if the change is non-additive.
+
+namespace ConfigBackup {
+
+// Migration hook for non-additive schema changes (field renames or semantic
+// changes). Mutates the parsed `config` object in place before the apply step.
+// No-op for version 1: additive changes are handled automatically by the
+// lenient apply (unknown keys ignored, absent keys left at current values).
+// Example future use: if cycleInterval units change between versions, rewrite
+// config["cycleInterval"] here based on fromVersion.
+static void migrate(JsonObject config, int fromVersion) {
+  (void)config;
+  (void)fromVersion;
+}
+
+String exportJson(bool includeSecrets) {
+  JsonDocument doc;
+
+  JsonObject meta = doc["_meta"].to<JsonObject>();
+  meta["schemaVersion"] = CONFIG_SCHEMA_VERSION;
+  meta["firmware"] = GIT_COMMIT_HASH;
+  meta["deviceName"] = configStorage.getDeviceName();
+  meta["displayType"] = configStorage.getDisplayType();
+  meta["secretsIncluded"] = includeSecrets;
+
+  JsonObject config = doc["config"].to<JsonObject>();
+
+  // Device
+  config["deviceName"] = configStorage.getDeviceName();
+
+  // Network
+  config["wifiProvisioned"] = configStorage.isWiFiProvisioned();
+  config["wifiSSID"] = configStorage.getWiFiSSID();
+  if (includeSecrets) config["wifiPassword"] = configStorage.getWiFiPassword();
+
+  // MQTT
+  config["mqttServer"] = configStorage.getMQTTServer();
+  config["mqttPort"] = configStorage.getMQTTPort();
+  config["mqttUser"] = configStorage.getMQTTUser();
+  if (includeSecrets) config["mqttPassword"] = configStorage.getMQTTPassword();
+  config["mqttClientID"] = configStorage.getMQTTClientID();
+
+  // Home Assistant Discovery
+  config["haDiscoveryEnabled"] = configStorage.getHADiscoveryEnabled();
+  config["haDeviceName"] = configStorage.getHADeviceName();
+  config["haDiscoveryPrefix"] = configStorage.getHADiscoveryPrefix();
+  config["haStateTopic"] = configStorage.getHAStateTopic();
+  config["haSensorUpdateInterval"] = configStorage.getHASensorUpdateInterval();
+
+  // Image (legacy single URL)
+  config["imageURL"] = configStorage.getImageURL();
+
+  // Multi-image cycling
+  config["cyclingEnabled"] = configStorage.getCyclingEnabled();
+  config["imageUpdateMode"] = configStorage.getImageUpdateMode();
+  config["cycleInterval"] = configStorage.getCycleInterval();
+  config["randomOrder"] = configStorage.getRandomOrder();
+  config["currentImageIndex"] = configStorage.getCurrentImageIndex();
+
+  // Image sources array
+  JsonArray sources = config["imageSources"].to<JsonArray>();
+  int count = configStorage.getImageSourceCount();
+  for (int i = 0; i < count && i < MAX_IMAGE_SOURCES; i++) {
+    JsonObject src = sources.add<JsonObject>();
+    src["url"] = configStorage.getImageSource(i);
+    src["enabled"] = configStorage.isImageEnabled(i);
+    src["duration"] = configStorage.getImageDuration(i);
+    src["scaleX"] = configStorage.getImageScaleX(i);
+    src["scaleY"] = configStorage.getImageScaleY(i);
+    src["offsetX"] = configStorage.getImageOffsetX(i);
+    src["offsetY"] = configStorage.getImageOffsetY(i);
+    src["rotation"] = configStorage.getImageRotation(i);
+  }
+
+  // Display
+  config["defaultBrightness"] = configStorage.getDefaultBrightness();
+  config["brightnessAutoMode"] = configStorage.getBrightnessAutoMode();
+  config["defaultScaleX"] = configStorage.getDefaultScaleX();
+  config["defaultScaleY"] = configStorage.getDefaultScaleY();
+  config["defaultOffsetX"] = configStorage.getDefaultOffsetX();
+  config["defaultOffsetY"] = configStorage.getDefaultOffsetY();
+  config["defaultRotation"] = configStorage.getDefaultRotation();
+  config["defaultImageDuration"] = configStorage.getDefaultImageDuration();
+  config["backlightFreq"] = configStorage.getBacklightFreq();
+  config["backlightResolution"] = configStorage.getBacklightResolution();
+
+  // Display hardware
+  config["displayType"] = configStorage.getDisplayType();
+  config["colorTemp"] = configStorage.getColorTemp();
+
+  // Moon render
+  config["moonLat"] = configStorage.getMoonLat();
+  config["moonLon"] = configStorage.getMoonLon();
+  config["moonBgStyle"] = configStorage.getMoonBgStyle();
+  config["moonFlipU"] = configStorage.getMoonFlipU();
+  config["moonFlipV"] = configStorage.getMoonFlipV();
+  config["moonRollOffset"] = configStorage.getMoonRollOffset();
+  config["moonYawOffset"] = configStorage.getMoonYawOffset();
+  config["moonPitchOffset"] = configStorage.getMoonPitchOffset();
+  config["moonNorthUp"] = configStorage.getMoonNorthUp();
+  config["moonDragLightMode"] = configStorage.getMoonDragLightMode();
+  config["moonSpinMode"] = configStorage.getMoonSpinMode();
+  config["moonSpinReturnS"] = configStorage.getMoonSpinReturnS();
+
+  // Advanced
+  config["updateInterval"] = configStorage.getUpdateInterval();
+  config["mqttReconnectInterval"] = configStorage.getMQTTReconnectInterval();
+  config["watchdogTimeout"] = configStorage.getWatchdogTimeout();
+  config["criticalHeapThreshold"] = configStorage.getCriticalHeapThreshold();
+  config["criticalPSRAMThreshold"] = configStorage.getCriticalPSRAMThreshold();
+
+  // Logging
+  config["minLogSeverity"] = configStorage.getMinLogSeverity();
+
+  // Time
+  config["ntpServer"] = configStorage.getNTPServer();
+  config["timezone"] = configStorage.getTimezone();
+  config["ntpEnabled"] = configStorage.getNTPEnabled();
+
+  // Home Assistant REST control
+  config["haBaseUrl"] = configStorage.getHABaseUrl();
+  if (includeSecrets) config["haAccessToken"] = configStorage.getHAAccessToken();
+  config["haLightSensorEntity"] = configStorage.getHALightSensorEntity();
+  config["lightSensorMinLux"] = configStorage.getLightSensorMinLux();
+  config["lightSensorMaxLux"] = configStorage.getLightSensorMaxLux();
+  config["displayMinBrightness"] = configStorage.getDisplayMinBrightness();
+  config["displayMaxBrightness"] = configStorage.getDisplayMaxBrightness();
+  config["useHaRestControl"] = configStorage.getUseHARestControl();
+  config["haPollInterval"] = configStorage.getHAPollInterval();
+  config["lightSensorMappingMode"] = configStorage.getLightSensorMappingMode();
+
+  String out;
+  serializeJson(doc, out);
+  return out;
+}
+
+RestoreResult importJson(const String& body) {
+  RestoreResult result;
+
+  JsonDocument doc;
+  DeserializationError err = deserializeJson(doc, body);
+  if (err) {
+    result.ok = false;
+    result.error = String("JSON parse error: ") + err.c_str();
+    return result;
+  }
+
+  if (!doc["config"].is<JsonObject>()) {
+    result.ok = false;
+    result.error = "Missing or invalid 'config' object";
+    return result;
+  }
+
+  JsonObject meta = doc["_meta"].is<JsonObject>() ? doc["_meta"].as<JsonObject>()
+                                                  : JsonObject();
+  result.fileVersion = meta["schemaVersion"] | 0;
+  result.versionMismatch = (result.fileVersion != CONFIG_SCHEMA_VERSION);
+  result.secretsIncluded = meta["secretsIncluded"] | false;
+
+  JsonObject config = doc["config"].as<JsonObject>();
+
+  if (result.fileVersion < CONFIG_SCHEMA_VERSION) {
+    migrate(config, result.fileVersion);
+  }
+
+  // Track which keys are recognized so anything left over counts as skipped.
+  // Each recognized scalar key present in `config` is applied and counted.
+  int applied = 0;
+  int skipped = 0;
+
+  // Helper macros keep the apply list compact and adjacent to the export list.
+  // Each checks presence via the typed is<T>() probe before calling the setter.
+  #define APPLY_STR(key, setter) \
+    if (config[key].is<const char*>()) { configStorage.setter(config[key].as<String>()); applied++; }
+  #define APPLY_BOOL(key, setter) \
+    if (config[key].is<bool>()) { configStorage.setter(config[key].as<bool>()); applied++; }
+  #define APPLY_INT(key, setter) \
+    if (config[key].is<int>()) { configStorage.setter(config[key].as<int>()); applied++; }
+  #define APPLY_UL(key, setter) \
+    if (config[key].is<unsigned long>() || config[key].is<long>() || config[key].is<int>()) \
+      { configStorage.setter(config[key].as<unsigned long>()); applied++; }
+  #define APPLY_FLOAT(key, setter) \
+    if (config[key].is<float>() || config[key].is<int>()) { configStorage.setter(config[key].as<float>()); applied++; }
+  #define APPLY_SIZE(key, setter) \
+    if (config[key].is<unsigned long>() || config[key].is<long>() || config[key].is<int>()) \
+      { configStorage.setter((size_t)(config[key].as<unsigned long>())); applied++; }
+  #define APPLY_U8(key, setter) \
+    if (config[key].is<int>()) { configStorage.setter((uint8_t)(config[key].as<int>())); applied++; }
+
+  // Secret string: apply only when present AND non-empty, so a no-secrets
+  // backup never erases existing credentials.
+  #define APPLY_SECRET(key, setter) \
+    if (config[key].is<const char*>()) { \
+      String v = config[key].as<String>(); \
+      if (v.length() > 0) { configStorage.setter(v); applied++; } \
+    }
+
+  // Device
+  APPLY_STR("deviceName", setDeviceName);
+
+  // Network
+  APPLY_BOOL("wifiProvisioned", setWiFiProvisioned);
+  APPLY_STR("wifiSSID", setWiFiSSID);
+  APPLY_SECRET("wifiPassword", setWiFiPassword);
+
+  // MQTT
+  APPLY_STR("mqttServer", setMQTTServer);
+  APPLY_INT("mqttPort", setMQTTPort);
+  APPLY_STR("mqttUser", setMQTTUser);
+  APPLY_SECRET("mqttPassword", setMQTTPassword);
+  APPLY_STR("mqttClientID", setMQTTClientID);
+
+  // Home Assistant Discovery
+  APPLY_BOOL("haDiscoveryEnabled", setHADiscoveryEnabled);
+  APPLY_STR("haDeviceName", setHADeviceName);
+  APPLY_STR("haDiscoveryPrefix", setHADiscoveryPrefix);
+  APPLY_STR("haStateTopic", setHAStateTopic);
+  APPLY_UL("haSensorUpdateInterval", setHASensorUpdateInterval);
+
+  // Image (legacy single URL)
+  APPLY_STR("imageURL", setImageURL);
+
+  // Multi-image cycling
+  APPLY_BOOL("cyclingEnabled", setCyclingEnabled);
+  APPLY_INT("imageUpdateMode", setImageUpdateMode);
+  APPLY_UL("cycleInterval", setCycleInterval);
+  APPLY_BOOL("randomOrder", setRandomOrder);
+  // NOTE: currentImageIndex is applied AFTER the image sources are rebuilt
+  // (clearImageSources resets it to 0 and setCurrentImageIndex validates against
+  // the live source count), see below.
+
+  // Display
+  APPLY_INT("defaultBrightness", setDefaultBrightness);
+  APPLY_BOOL("brightnessAutoMode", setBrightnessAutoMode);
+  APPLY_FLOAT("defaultScaleX", setDefaultScaleX);
+  APPLY_FLOAT("defaultScaleY", setDefaultScaleY);
+  APPLY_INT("defaultOffsetX", setDefaultOffsetX);
+  APPLY_INT("defaultOffsetY", setDefaultOffsetY);
+  APPLY_FLOAT("defaultRotation", setDefaultRotation);
+  APPLY_UL("defaultImageDuration", setDefaultImageDuration);
+  APPLY_INT("backlightFreq", setBacklightFreq);
+  APPLY_INT("backlightResolution", setBacklightResolution);
+
+  // Display hardware
+  APPLY_INT("displayType", setDisplayType);
+  APPLY_INT("colorTemp", setColorTemp);
+
+  // Moon render
+  APPLY_FLOAT("moonLat", setMoonLat);
+  APPLY_FLOAT("moonLon", setMoonLon);
+  APPLY_INT("moonBgStyle", setMoonBgStyle);
+  APPLY_U8("moonFlipU", setMoonFlipU);
+  APPLY_U8("moonFlipV", setMoonFlipV);
+  APPLY_FLOAT("moonRollOffset", setMoonRollOffset);
+  APPLY_FLOAT("moonYawOffset", setMoonYawOffset);
+  APPLY_FLOAT("moonPitchOffset", setMoonPitchOffset);
+  APPLY_U8("moonNorthUp", setMoonNorthUp);
+  APPLY_U8("moonDragLightMode", setMoonDragLightMode);
+  APPLY_U8("moonSpinMode", setMoonSpinMode);
+  APPLY_U8("moonSpinReturnS", setMoonSpinReturnS);
+
+  // Advanced
+  APPLY_UL("updateInterval", setUpdateInterval);
+  APPLY_UL("mqttReconnectInterval", setMQTTReconnectInterval);
+  APPLY_UL("watchdogTimeout", setWatchdogTimeout);
+  APPLY_SIZE("criticalHeapThreshold", setCriticalHeapThreshold);
+  APPLY_SIZE("criticalPSRAMThreshold", setCriticalPSRAMThreshold);
+
+  // Logging
+  APPLY_INT("minLogSeverity", setMinLogSeverity);
+
+  // Time
+  APPLY_STR("ntpServer", setNTPServer);
+  APPLY_STR("timezone", setTimezone);
+  APPLY_BOOL("ntpEnabled", setNTPEnabled);
+
+  // Home Assistant REST control
+  APPLY_STR("haBaseUrl", setHABaseUrl);
+  APPLY_SECRET("haAccessToken", setHAAccessToken);
+  APPLY_STR("haLightSensorEntity", setHALightSensorEntity);
+  APPLY_FLOAT("lightSensorMinLux", setLightSensorMinLux);
+  APPLY_FLOAT("lightSensorMaxLux", setLightSensorMaxLux);
+  APPLY_INT("displayMinBrightness", setDisplayMinBrightness);
+  APPLY_INT("displayMaxBrightness", setDisplayMaxBrightness);
+  APPLY_BOOL("useHaRestControl", setUseHARestControl);
+  APPLY_UL("haPollInterval", setHAPollInterval);
+  APPLY_INT("lightSensorMappingMode", setLightSensorMappingMode);
+
+  #undef APPLY_STR
+  #undef APPLY_BOOL
+  #undef APPLY_INT
+  #undef APPLY_UL
+  #undef APPLY_FLOAT
+  #undef APPLY_SIZE
+  #undef APPLY_U8
+  #undef APPLY_SECRET
+
+  // Image sources: rebuild the array from scratch. Extras beyond
+  // MAX_IMAGE_SOURCES are skipped and counted.
+  if (config["imageSources"].is<JsonArray>()) {
+    JsonArray sources = config["imageSources"].as<JsonArray>();
+    configStorage.clearImageSources();
+    int idx = 0;
+    for (JsonObject src : sources) {
+      if (idx >= MAX_IMAGE_SOURCES) {
+        skipped++;
+        continue;
+      }
+      String url = src["url"].is<const char*>() ? src["url"].as<String>() : String("");
+      configStorage.addImageSource(url);
+      if (src["enabled"].is<bool>())   configStorage.setImageEnabled(idx, src["enabled"].as<bool>());
+      if (src["duration"].is<int>() || src["duration"].is<unsigned long>() || src["duration"].is<long>())
+        configStorage.setImageDuration(idx, src["duration"].as<unsigned long>());
+      if (src["scaleX"].is<float>() || src["scaleX"].is<int>())   configStorage.setImageScaleX(idx, src["scaleX"].as<float>());
+      if (src["scaleY"].is<float>() || src["scaleY"].is<int>())   configStorage.setImageScaleY(idx, src["scaleY"].as<float>());
+      if (src["offsetX"].is<int>())  configStorage.setImageOffsetX(idx, src["offsetX"].as<int>());
+      if (src["offsetY"].is<int>())  configStorage.setImageOffsetY(idx, src["offsetY"].as<int>());
+      if (src["rotation"].is<float>() || src["rotation"].is<int>()) configStorage.setImageRotation(idx, src["rotation"].as<float>());
+      applied++;
+      idx++;
+    }
+  } else {
+    // Count an unrecognized imageSources value (e.g. wrong type) as skipped if present.
+    if (!config["imageSources"].isNull()) skipped++;
+  }
+
+  // Apply currentImageIndex now that the source array (and its count) is rebuilt.
+  // setCurrentImageIndex validates the index against the live source count.
+  if (config["currentImageIndex"].is<int>()) {
+    configStorage.setCurrentImageIndex(config["currentImageIndex"].as<int>());
+    applied++;
+  }
+
+  // Count any keys in `config` that we did not recognize as skipped.
+  // Recognized keys were applied above; everything else is unknown.
+  // (Scalar keys with a wrong/absent type that we did not apply also fall here.)
+  // We approximate by counting members not in the recognized set.
+  static const char* kKnown[] = {
+    "deviceName","wifiProvisioned","wifiSSID","wifiPassword",
+    "mqttServer","mqttPort","mqttUser","mqttPassword","mqttClientID",
+    "haDiscoveryEnabled","haDeviceName","haDiscoveryPrefix","haStateTopic","haSensorUpdateInterval",
+    "imageURL","cyclingEnabled","imageUpdateMode","cycleInterval","randomOrder","currentImageIndex",
+    "imageSources",
+    "defaultBrightness","brightnessAutoMode","defaultScaleX","defaultScaleY","defaultOffsetX",
+    "defaultOffsetY","defaultRotation","defaultImageDuration","backlightFreq","backlightResolution",
+    "displayType","colorTemp",
+    "moonLat","moonLon","moonBgStyle","moonFlipU","moonFlipV","moonRollOffset","moonYawOffset",
+    "moonPitchOffset","moonNorthUp","moonDragLightMode","moonSpinMode","moonSpinReturnS",
+    "updateInterval","mqttReconnectInterval","watchdogTimeout","criticalHeapThreshold","criticalPSRAMThreshold",
+    "minLogSeverity","ntpServer","timezone","ntpEnabled",
+    "haBaseUrl","haAccessToken","haLightSensorEntity","lightSensorMinLux","lightSensorMaxLux",
+    "displayMinBrightness","displayMaxBrightness","useHaRestControl","haPollInterval","lightSensorMappingMode"
+  };
+  const int kKnownCount = sizeof(kKnown) / sizeof(kKnown[0]);
+  for (JsonPair kv : config) {
+    bool known = false;
+    for (int i = 0; i < kKnownCount; i++) {
+      if (strcmp(kv.key().c_str(), kKnown[i]) == 0) { known = true; break; }
+    }
+    if (!known) skipped++;
+  }
+
+  configStorage.saveConfig();
+
+  result.ok = true;
+  result.applied = applied;
+  result.skipped = skipped;
+  return result;
+}
+
+}  // namespace ConfigBackup

--- a/config_backup.h
+++ b/config_backup.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <Arduino.h>
+
+// Config backup/restore module. Single owner of the mapping between
+// ConfigStorage state and the versioned JSON backup document.
+namespace ConfigBackup {
+  struct RestoreResult {
+    bool ok = false;
+    String error;
+    int fileVersion = 0;
+    int applied = 0;
+    int skipped = 0;
+    bool versionMismatch = false;
+    bool secretsIncluded = false;
+  };
+
+  // Serialize the full device configuration to JSON. When includeSecrets is
+  // false the wifiPassword, mqttPassword, and haAccessToken keys are omitted.
+  String exportJson(bool includeSecrets);
+
+  // Parse a backup document and apply recognized fields through ConfigStorage
+  // setters, then saveConfig(). Does not reboot; the caller handles that.
+  RestoreResult importJson(const String& body);
+}

--- a/docs/03_configuration.md
+++ b/docs/03_configuration.md
@@ -10,6 +10,7 @@ Complete guide to configuring the ESP32-P4 AllSky Display firmware, covering bot
 - [Web UI Configuration](#web-ui-configuration)
 - [MQTT Configuration](#mqtt-configuration)
 - [Multi-Image Setup](#multi-image-setup)
+- [Backup and Restore](#backup-and-restore)
 - [Serial Commands Reference](#serial-commands-reference)
 - [Advanced Configuration](#advanced-configuration)
 
@@ -647,6 +648,57 @@ mkdir -p "${OUTPUT_DIR}"
 
 1. **AllSky Module** (Recommended): Use the [allsky_esp32round module](https://github.com/AllskyTeam/allsky-modules/tree/master/allsky_esp32round) → Use `http://your-server/resized/image.jpg`
 2. **Custom Script**: Add script to AllSky Module Manager or run via cron job every 1-10 minutes with `crontab -e`
+
+---
+
+## Backup and Restore
+
+Export the full device configuration to a file, then restore that file onto a device that has been wiped or reset. The backup captures runtime settings stored in NVS: device name, WiFi, MQTT, Home Assistant, image sources and transforms, display settings, and system thresholds. Compile-time settings are not part of a backup.
+
+### Where the Controls Live
+
+The controls are on the System settings page, in the "Backup and Restore" card.
+
+1. Navigate to `http://allskyesp32.lan:8080/system`
+2. Find the "Backup and Restore" card
+
+The card contains a "Download backup" button, an "Include passwords and tokens" checkbox, a file picker, and a "Restore and reboot" button.
+
+### Download a Backup
+
+1. Decide whether to include secrets. The "Include passwords and tokens" checkbox controls whether the WiFi password, MQTT password, and Home Assistant access token are written to the file.
+2. Select "Download backup". The browser saves a `.json` file named after the device.
+
+Warning: when "Include passwords and tokens" is checked, the secrets are stored in plaintext in the downloaded file. There is no encryption. Store the file in a protected location. When the checkbox is unchecked, the secret keys are omitted from the file, and other identifiers such as the WiFi SSID and MQTT username are still written.
+
+### Restore and Reboot
+
+1. Select the file picker and choose a `.json` backup file.
+2. Select "Restore and reboot" and confirm the prompt.
+3. The device applies the recognized settings, saves them to NVS, and reboots. After the reboot, the device runs with the restored settings.
+
+A restore that fails to parse the file does not reboot the device.
+
+### Version Behavior
+
+The backup file carries a schema version. Restore is lenient and best-effort:
+
+- Recognized fields are applied.
+- Unknown fields are ignored.
+- Fields absent from the file keep their current value on the device.
+- A backup made on a different schema version still restores. The restore proceeds and reports a version mismatch warning.
+- A no-secrets backup does not erase existing credentials. Secret fields are applied only when present and non-empty, so restoring a file saved without secrets leaves the current WiFi password, MQTT password, and Home Assistant token in place.
+
+### Wipe Then Restore Sequence
+
+After a factory reset the web UI is not reachable until WiFi is configured, because a factory reset clears WiFi credentials. Use this order:
+
+1. Factory reset the device.
+2. Complete WiFi setup through the captive portal so the device joins your network and the web UI becomes reachable.
+3. Open the System settings page and restore the backup file.
+4. The device reboots with the restored configuration.
+
+If the backup includes secrets, the restored WiFi credentials take effect after the reboot. If the backup excludes secrets, the WiFi credentials entered during setup are retained.
 
 ---
 

--- a/docs/developer/api_reference.md
+++ b/docs/developer/api_reference.md
@@ -835,6 +835,59 @@ bool isRunning();
 bool isOTAInProgress() const;
 ```
 
+### REST API Endpoints
+
+#### GET /api/backup
+
+Returns the device configuration as a JSON file attachment.
+
+Query parameters:
+
+| Parameter | Values | Description |
+|-----------|--------|-------------|
+| `secrets` | `0` or `1` | `1` includes passwords and tokens (WiFi password, MQTT password, Home Assistant access token). `0` omits them. |
+
+Response: the configuration document with `Content-Type: application/json` and a `Content-Disposition: attachment` header. The filename is derived from the device name.
+
+Example:
+
+```bash
+# Download a backup with secrets included
+curl -OJ "http://allskyesp32.lan:8080/api/backup?secrets=1"
+
+# Download a backup without secrets
+curl -OJ "http://allskyesp32.lan:8080/api/backup?secrets=0"
+```
+
+#### POST /api/restore
+
+Applies a backup file, saves the configuration, and reboots on success.
+
+Request body: the raw backup file text (the JSON document returned by `GET /api/backup`). The body is read from the `plain` argument.
+
+Behavior: the handler parses the body, applies every recognized field through the matching `ConfigStorage` setters, saves the configuration, then reboots the device. Unknown fields are ignored. Absent fields keep their current value. Secret fields are applied only when present and non-empty, so a no-secrets backup does not erase existing credentials.
+
+Response JSON fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | Result of the restore. |
+| `message` | string | Human-readable detail. |
+| `applied` | number | Count of recognized fields applied. |
+| `skipped` | number | Count of unknown fields ignored. |
+| `fileVersion` | number | Schema version read from the file. Absent value is treated as 0. |
+| `versionMismatch` | boolean | `true` when `fileVersion` differs from the firmware schema version. The restore still proceeds. |
+
+Errors: an empty or unparseable body returns HTTP 400 and does not reboot. A successful restore reboots after sending the response.
+
+Example:
+
+```bash
+# Restore a previously downloaded backup
+curl -X POST "http://allskyesp32.lan:8080/api/restore" \
+  --data-binary @allsky-config-backup.json
+```
+
 ---
 
 ## ConfigStorage

--- a/docs/superpowers/plans/2026-06-14-config-backup-restore.md
+++ b/docs/superpowers/plans/2026-06-14-config-backup-restore.md
@@ -1,0 +1,149 @@
+# Config Backup and Restore Implementation Plan
+
+Date: 2026-06-14
+Spec: docs/superpowers/specs/2026-06-14-config-backup-restore-design.md
+
+## Overview
+
+Add export and import of the full device configuration as a versioned JSON file,
+with a reboot after restore. Work is split into four file-ownership lanes that
+code against the fixed interface below so they can proceed in parallel.
+
+## Fixed interface (all lanes code to this)
+
+config_backup.h:
+
+```cpp
+#pragma once
+#include <Arduino.h>
+
+namespace ConfigBackup {
+  struct RestoreResult {
+    bool ok = false;
+    String error;
+    int fileVersion = 0;
+    int applied = 0;
+    int skipped = 0;
+    bool versionMismatch = false;
+    bool secretsIncluded = false;
+  };
+
+  String exportJson(bool includeSecrets);
+  RestoreResult importJson(const String& body);
+}
+```
+
+Endpoints:
+- `GET /api/backup?secrets=0|1` returns the file as an attachment.
+- `POST /api/restore` body is the raw file text; returns a JSON result and, on
+  success, reboots.
+
+`config.h` gains `#define CONFIG_SCHEMA_VERSION 1`.
+
+## Lane A: Core module (owns config.h addition, config_backup.h, config_backup.cpp)
+
+1. Add `#define CONFIG_SCHEMA_VERSION 1` to config.h in the IMAGE/SYSTEM area.
+2. Create config_backup.h with the interface above.
+3. Implement `exportJson(bool includeSecrets)`:
+   - Build a `JsonDocument`.
+   - Fill `_meta`: `schemaVersion` = `CONFIG_SCHEMA_VERSION`, `firmware` =
+     `GIT_COMMIT_HASH` (include build_info.h), `deviceName`, `displayType`,
+     `secretsIncluded`.
+   - Fill `config` with every scalar field from `configStorage` getters, matching
+     the key names in the spec format.
+   - Build `imageSources` as an array of objects for indices
+     `0 .. getImageSourceCount()-1`, each with url, enabled, duration, scaleX,
+     scaleY, offsetX, offsetY, rotation.
+   - Omit `wifiPassword`, `mqttPassword`, `haAccessToken` when `includeSecrets`
+     is false.
+   - `serializeJson` to a `String` and return it.
+4. Implement `importJson(const String& body)`:
+   - `deserializeJson`. On error or missing `config` object, return
+     `{ ok=false, error=... }`.
+   - Read `_meta.schemaVersion` into `fileVersion` (default 0). Set
+     `versionMismatch = (fileVersion != CONFIG_SCHEMA_VERSION)`. Set
+     `secretsIncluded` from `_meta.secretsIncluded`.
+   - If `fileVersion < CONFIG_SCHEMA_VERSION`, call `migrate(config, fileVersion)`.
+   - For each recognized scalar key present, call the matching setter and
+     increment `applied`; for unrecognized keys increment `skipped`.
+   - Secret fields: apply only when present and non-empty.
+   - Image sources: `configStorage.clearImageSources()`, then iterate the array
+     up to `MAX_IMAGE_SOURCES`; for each, `addImageSource(url)` then set enabled,
+     duration, and the five transform fields by index. Skip and count extras.
+   - Restore `currentImageIndex` and `imageSourceCount` consistency through the
+     existing setters.
+   - `configStorage.saveConfig()`.
+   - Return the populated result.
+5. Add `static void migrate(JsonObject config, int fromVersion)` as a no-op with
+   a comment describing how to add future migrations.
+
+Notes:
+- Use ArduinoJson 7 API (`JsonDocument`, `doc["config"].to<JsonObject>()`, etc.).
+- Guard array bounds with `MAX_IMAGE_SOURCES`.
+- Do not reboot here.
+
+## Lane B: Web transport (owns web_config.h, route block in web_config.cpp, handlers in web_config_api.cpp)
+
+1. web_config.h: declare `void handleBackup();` and `void handleRestore();`.
+2. web_config.cpp: register routes near the factory-reset and restart routes:
+   - `server->on("/api/backup", HTTP_GET, [this]() { handleBackup(); });`
+   - `server->on("/api/restore", HTTP_POST, [this]() { handleRestore(); });`
+3. web_config_api.cpp: add `#include "config_backup.h"`.
+4. `handleBackup()`:
+   - `bool includeSecrets = server->hasArg("secrets") && server->arg("secrets") == "1";`
+   - `String body = ConfigBackup::exportJson(includeSecrets);`
+   - Set header `Content-Disposition: attachment; filename="allsky-config.json"`
+     using `server->sendHeader(...)`, then `sendResponse(200, "application/json", body)`.
+5. `handleRestore()`:
+   - If no body (`!server->hasArg("plain")` or empty), respond HTTP 400 JSON error.
+   - `ConfigBackup::RestoreResult r = ConfigBackup::importJson(server->arg("plain"));`
+   - Build a JSON result with `status`, `message`, `applied`, `skipped`,
+     `fileVersion`, `versionMismatch`.
+   - If `!r.ok`, respond HTTP 400 and return without rebooting.
+   - On success respond HTTP 200, then `delay(500); crashLogger.saveBeforeReboot();
+     ESP.restart();` matching `handleRestart`.
+
+## Lane C: UI (owns the System page generator in web_config_pages.cpp)
+
+1. Locate the System settings page generator (the function behind
+   `/config/system`, `handleAdvancedConfig` / `generateAdvancedPage`).
+2. Add a "Backup and Restore" card consistent with existing card styling:
+   - "Download backup" button and an "Include passwords and tokens" checkbox.
+     The button triggers a navigation or fetch to
+     `/api/backup?secrets=` + (checkbox ? `1` : `0`) that saves the file.
+   - A file input and a "Restore and reboot" button. On click: confirm prompt,
+     read the file with `FileReader.readAsText`, `fetch('/api/restore', { method:
+     'POST', body: text })`, then show the returned message. Warn that the device
+     will reboot. If `versionMismatch` is true, surface that in the message.
+   - Note in the card that included secrets are stored in plaintext in the file.
+3. Reuse existing toast or status helpers on the page if present.
+
+## Lane D: Docs (owns docs/03_configuration.md and docs/developer/api_reference.md)
+
+1. docs/03_configuration.md: add a "Backup and restore" section describing the
+   download, the secrets checkbox, the restore-and-reboot flow, and the version
+   behavior.
+2. docs/developer/api_reference.md: document `GET /api/backup` and
+   `POST /api/restore`, parameters, response shape, and the reboot side effect.
+3. Follow the repository documentation style: no em dashes, no emojis, factual.
+
+## Integration and verification (lead, after lanes merge)
+
+1. Confirm config_backup.cpp compiles into the sketch (Arduino flat layout picks
+   up new .cpp automatically).
+2. Confirm the header/source pair check in CI passes (config_backup.h has a
+   matching .cpp).
+3. Compile for `esp32:esp32:esp32p4` locally if arduino-cli is available;
+   otherwise rely on CI. Resolve any errors.
+4. Review the round trip against the spec test list, focusing on secret omission,
+   image-source reconstruction, and the version-mismatch report.
+
+## Risks
+
+- ESP32 WebServer body access: confirm `server->arg("plain")` holds the POST body
+  for a non-form content type. If not, fall back to reading the body via an
+  upload handler.
+- JSON document size: roughly 6 to 8 KB. Allocate on heap (default ArduinoJson 7
+  behavior). The device has PSRAM headroom.
+- Field list drift: the export and import key lists must stay in sync with
+  `ConfigStorage`. Keep both in config_backup.cpp so they are edited together.

--- a/docs/superpowers/specs/2026-06-14-config-backup-restore-design.md
+++ b/docs/superpowers/specs/2026-06-14-config-backup-restore-design.md
@@ -1,0 +1,238 @@
+# Config Backup and Restore Design
+
+Date: 2026-06-14
+Status: Approved for implementation
+
+## Purpose
+
+Let a user export the full device configuration to a downloadable file, then
+restore that file onto a device that has been wiped or reset. After a successful
+restore the device reboots so the restored settings take effect. The file format
+carries a schema version so future firmware can read older backups without data
+loss.
+
+## Decisions
+
+- Backup scope: everything, with secrets optional. A checkbox at backup time
+  controls whether passwords and tokens are written to the file.
+- Version policy: lenient best-effort. Restore applies every field the running
+  firmware recognizes, ignores unknown fields, leaves absent fields at their
+  current values, and proceeds even when the file's schema version differs.
+- Transport: JSON file download and upload through the web UI.
+
+## Context
+
+- Configuration lives in NVS through the `Preferences` API, managed by
+  `ConfigStorage` in config_storage.cpp. Roughly 80 scalar fields plus three
+  parallel arrays for up to 10 image sources (URL, enabled flag, duration) and a
+  per-image transform struct (scaleX, scaleY, offsetX, offsetY, rotation).
+- Setters mark per-group dirty bits and many clamp or normalize their input
+  (for example `setCycleInterval`, `setImageScaleX`, `setImageRotation`).
+  `saveConfig()` writes only dirty groups.
+- ArduinoJson 7.4.3 is already installed by the build workflow
+  (.github/workflows/arduino-compile.yml). No new dependency or CI change is
+  required.
+- The web layer hand-builds JSON response strings and registers routes in
+  web_config.cpp. `handleFactoryReset` and `handleRestart` in web_config_api.cpp
+  show the reboot pattern: respond, `delay(500)`, `crashLogger.saveBeforeReboot()`,
+  `ESP.restart()`.
+- build_info.h provides `GIT_COMMIT_HASH` for firmware identification.
+- There is currently no firmware or config schema version constant.
+
+## Architecture
+
+A new module, `config_backup`, owns the mapping between the `ConfigStorage`
+state and the JSON backup document. It is the single place that knows the field
+list and the file format. The web layer calls into it and handles transport and
+reboot. The UI lives on the existing System settings page.
+
+```
+Browser (System page)
+  |  GET /api/backup?secrets=0|1            POST /api/restore  (body = file text)
+  v                                          v
+WebConfig::handleBackup                     WebConfig::handleRestore
+  |  ConfigBackup::exportJson(secrets)        |  ConfigBackup::importJson(body)
+  v                                           v   (apply via ConfigStorage setters)
+ConfigStorage getters                       ConfigStorage setters + saveConfig()
+                                             then reboot
+```
+
+### Components
+
+1. config.h
+   - Add `#define CONFIG_SCHEMA_VERSION 1`. This integer is bumped whenever the
+     field set or field semantics change.
+
+2. config_backup.h / config_backup.cpp (new)
+   - `String ConfigBackup::exportJson(bool includeSecrets)`
+     Builds a `JsonDocument` from `configStorage` getters and returns the
+     serialized text. Includes a `_meta` object and a `config` object.
+   - `struct ConfigBackup::RestoreResult { bool ok; String error; int fileVersion;
+     int applied; int skipped; bool versionMismatch; bool secretsIncluded; };`
+   - `RestoreResult ConfigBackup::importJson(const String& body)`
+     Parses the document, runs any version migration, applies recognized fields
+     through `ConfigStorage` setters, then calls `configStorage.saveConfig()`.
+     Does not reboot; the caller does.
+   - `static void migrate(JsonObject config, int fromVersion)`
+     No-op for version 1. Documented extension point for future renames or
+     semantic changes. Additive field changes need no migration because lenient
+     apply handles them automatically.
+
+3. web_config.h / web_config.cpp
+   - Declare `handleBackup()` and `handleRestore()`.
+   - Register `GET /api/backup` and `POST /api/restore` next to the existing
+     `/api/factory-reset` and `/api/restart` routes.
+
+4. web_config_api.cpp
+   - `handleBackup()`: read the `secrets` query argument, call
+     `ConfigBackup::exportJson`, send the result with
+     `Content-Disposition: attachment; filename="allsky-config-<deviceName>.json"`
+     and content type `application/json`.
+   - `handleRestore()`: read the uploaded file text from `server->arg("plain")`,
+     call `ConfigBackup::importJson`, send a JSON result describing what was
+     applied, then if `ok` reboot using the existing pattern.
+
+5. web_config_pages.cpp
+   - Add a "Backup and Restore" card to the System settings page with:
+     a "Download backup" button, an "Include passwords and tokens" checkbox,
+     a file picker, and a "Restore and reboot" button with a confirmation prompt.
+     Restore JS uses `FileReader` to read the chosen file as text and POSTs the
+     text as the request body to `/api/restore`.
+
+6. Docs
+   - Update docs/03_configuration.md and docs/developer/api_reference.md with the
+     feature description and the two endpoints.
+
+## Backup file format
+
+```json
+{
+  "_meta": {
+    "schemaVersion": 1,
+    "firmware": "abc1234",
+    "deviceName": "ESP32 AllSky Display",
+    "displayType": 1,
+    "secretsIncluded": true
+  },
+  "config": {
+    "deviceName": "...",
+    "wifiProvisioned": true,
+    "wifiSSID": "...",
+    "wifiPassword": "...",
+    "mqttServer": "...", "mqttPort": 1883, "mqttUser": "...", "mqttPassword": "...",
+    "mqttClientID": "...",
+    "haDiscoveryEnabled": true, "haDeviceName": "...", "haDiscoveryPrefix": "...",
+    "haStateTopic": "...", "haSensorUpdateInterval": 30,
+    "imageURL": "...",
+    "cyclingEnabled": true, "imageUpdateMode": 0, "cycleInterval": 30000,
+    "randomOrder": false, "currentImageIndex": 0,
+    "imageSources": [
+      { "url": "...", "enabled": true, "duration": 30,
+        "scaleX": 1.2, "scaleY": 1.2, "offsetX": 0, "offsetY": 0, "rotation": 0 }
+    ],
+    "defaultBrightness": 50, "brightnessAutoMode": true,
+    "defaultScaleX": 1.2, "defaultScaleY": 1.2, "defaultOffsetX": 0,
+    "defaultOffsetY": 0, "defaultRotation": 0, "defaultImageDuration": 30,
+    "backlightFreq": 5000, "backlightResolution": 10,
+    "displayType": 1, "colorTemp": 6500,
+    "moonLat": 0, "moonLon": 0, "moonBgStyle": 3,
+    "moonFlipU": 0, "moonFlipV": 0, "moonRollOffset": 0, "moonYawOffset": 0,
+    "moonPitchOffset": 0, "moonNorthUp": 1, "moonDragLightMode": 0,
+    "moonSpinMode": 0, "moonSpinReturnS": 3,
+    "updateInterval": 120000, "mqttReconnectInterval": 5000,
+    "watchdogTimeout": 90000, "criticalHeapThreshold": 50000,
+    "criticalPSRAMThreshold": 100000,
+    "minLogSeverity": 0,
+    "ntpServer": "pool.ntp.org", "timezone": "CST6CDT,M3.2.0,M11.1.0",
+    "ntpEnabled": true,
+    "haBaseUrl": "...", "haAccessToken": "...", "haLightSensorEntity": "...",
+    "lightSensorMinLux": 0, "lightSensorMaxLux": 300,
+    "displayMinBrightness": 10, "displayMaxBrightness": 100,
+    "useHaRestControl": false, "haPollInterval": 60, "lightSensorMappingMode": 1
+  }
+}
+```
+
+Secret fields are `wifiPassword`, `mqttPassword`, and `haAccessToken`. When the
+backup excludes secrets, these keys are omitted from the file. `wifiSSID`,
+`mqttUser`, and other identifiers are not treated as secrets.
+
+## Data flow
+
+### Backup
+1. User selects "Download backup", optionally checks "Include passwords and tokens".
+2. Browser requests `GET /api/backup?secrets=1` (or `secrets=0`).
+3. `handleBackup` calls `ConfigBackup::exportJson(includeSecrets)`.
+4. `exportJson` reads every field through `configStorage` getters, builds the
+   `_meta` and `config` objects, and serializes.
+5. Response is sent as a file attachment; the browser saves it.
+
+### Restore
+1. User chooses a file and selects "Restore and reboot", confirming the prompt.
+2. Browser reads the file text and POSTs it as the body to `/api/restore`.
+3. `handleRestore` reads `server->arg("plain")` and calls
+   `ConfigBackup::importJson`.
+4. `importJson`:
+   - Parses JSON. On parse error returns `ok = false` with an error string.
+   - Reads `_meta.schemaVersion` into `fileVersion`. Sets `versionMismatch` when
+     it differs from `CONFIG_SCHEMA_VERSION`. An absent value is treated as 0.
+   - Calls `migrate(config, fileVersion)` when `fileVersion < CONFIG_SCHEMA_VERSION`.
+   - For each recognized key present in `config`, calls the matching
+     `ConfigStorage` setter, counting `applied`. Unknown keys count as `skipped`.
+   - For image sources: `clearImageSources()`, then for each array element up to
+     `MAX_IMAGE_SOURCES` add the URL and set enabled, duration, and transform.
+   - Secrets: a secret field is applied only when present and non-empty, so a
+     no-secrets backup never erases existing credentials.
+   - Calls `configStorage.saveConfig()`.
+5. `handleRestore` sends a JSON result, then if `ok` runs the reboot pattern
+   (`delay(500)`, `crashLogger.saveBeforeReboot()`, `ESP.restart()`).
+
+## Version management
+
+- `CONFIG_SCHEMA_VERSION` starts at 1.
+- Bump the constant when fields are added, renamed, removed, or change meaning.
+- Lenient apply already handles additive changes: a new firmware reading an old
+  file simply leaves new fields at defaults; an old firmware reading a new file
+  ignores unknown keys.
+- `migrate(JsonObject config, int fromVersion)` is the hook for non-additive
+  changes. Example future use: if `cycleInterval` units change, the migration
+  rewrites the value in the parsed document before the apply step. Version 1
+  ships an empty `migrate`.
+- The restore result reports `fileVersion` and `versionMismatch` so the UI can
+  warn the user that a cross-version restore was applied on a best-effort basis.
+
+## Error handling
+
+- Empty or missing request body: `handleRestore` returns HTTP 400 with an error
+  message, no reboot.
+- JSON parse failure: `importJson` returns `ok = false`; handler returns HTTP 400.
+- Missing `config` object: treated as parse failure.
+- Out-of-range values: existing setters clamp or normalize, so malformed numbers
+  cannot corrupt state.
+- More than `MAX_IMAGE_SOURCES` entries: extra entries are skipped and counted.
+- Partial application never reboots unless `ok` is true and at least the parse
+  succeeded.
+
+## Testing
+
+Manual verification on device:
+1. Configure non-default values across several sections.
+2. Download a backup with secrets included; confirm the file contains the
+   expected fields and the `_meta` block.
+3. Download a backup with secrets excluded; confirm secret keys are absent.
+4. Factory reset the device, complete WiFi setup, then restore the file and
+   confirm the device reboots and comes back with the saved settings.
+5. Restore a no-secrets backup and confirm existing credentials are retained.
+6. Hand-edit the file to set `_meta.schemaVersion` to a higher number and confirm
+   restore still applies recognized fields and reports a version mismatch.
+7. Restore a file with an unknown extra key and confirm it is ignored.
+
+Build verification: the sketch must compile for
+`esp32:esp32:esp32p4` with the existing libraries.
+
+## Out of scope
+
+- Automatic cloud or scheduled backups.
+- Encryption of the backup file. Secrets are stored in plaintext when included;
+  the UI warns the user.
+- Backup of crash logs or runtime state.

--- a/web_config.cpp
+++ b/web_config.cpp
@@ -64,6 +64,8 @@ bool WebConfig::begin(int port) {
         server->on("/api/update-image-duration", HTTP_POST, [this]() { handleUpdateImageDuration(); });
         server->on("/api/restart", HTTP_POST, [this]() { handleRestart(); });
         server->on("/api/factory-reset", HTTP_POST, [this]() { handleFactoryReset(); });
+        server->on("/api/backup", HTTP_GET, [this]() { handleBackup(); });
+        server->on("/api/restore", HTTP_POST, [this]() { handleRestore(); });
         server->on("/api/set-log-severity", HTTP_POST, [this]() { handleSetLogSeverity(); });
         server->on("/api/clear-crash-logs", HTTP_POST, [this]() { handleClearCrashLogs(); });
         server->on("/api/force-brightness-update", HTTP_POST, [this]() { handleForceBrightnessUpdate(); });

--- a/web_config.h
+++ b/web_config.h
@@ -68,6 +68,8 @@ private:
     void handleUpdateImageDuration();
     void handleRestart();
     void handleFactoryReset();
+    void handleBackup();
+    void handleRestore();
     void handleSetLogSeverity();
     void handleClearCrashLogs();
     void handleForceBrightnessUpdate();

--- a/web_config_api.cpp
+++ b/web_config_api.cpp
@@ -12,6 +12,7 @@
 #include "ha_discovery.h"
 #include "logging.h"
 #include "image_presets.h"
+#include "config_backup.h"
 #include <Update.h>
 #include <driver/jpeg_encode.h>  // ESP32-P4 hardware JPEG encoder (screenshot endpoint)
 
@@ -1100,6 +1101,62 @@ void WebConfig::handleFactoryReset() {
     displayManager.debugPrint("Factory reset in progress...", COLOR_YELLOW);
     displayManager.debugPrint("WiFi setup portal will run on restart", COLOR_CYAN);
     
+    delay(500);
+    crashLogger.saveBeforeReboot();
+    ESP.restart();
+}
+
+void WebConfig::handleBackup() {
+    bool includeSecrets = server->hasArg("secrets") && server->arg("secrets") == "1";
+    LOG_INFO_F("[WebAPI] Configuration backup requested (secrets: %s)\n", includeSecrets ? "included" : "omitted");
+
+    String body = ConfigBackup::exportJson(includeSecrets);
+    server->sendHeader("Content-Disposition", "attachment; filename=\"allsky-config.json\"");
+    sendResponse(200, "application/json", body);
+}
+
+void WebConfig::handleRestore() {
+    if (!server->hasArg("plain") || server->arg("plain").length() == 0) {
+        LOG_WARNING("[WebAPI] Configuration restore called with empty body");
+        sendResponse(400, "application/json", "{\"status\":\"error\",\"message\":\"Request body is empty. Upload a backup file.\"}");
+        return;
+    }
+
+    LOG_INFO("[WebAPI] Configuration restore request received");
+    ConfigBackup::RestoreResult r = ConfigBackup::importJson(server->arg("plain"));
+
+    // Build the human-readable message, noting cross-version restores.
+    String message;
+    if (r.ok) {
+        message = "Configuration restored. Device restarting now...";
+        if (r.versionMismatch) {
+            message = "Configuration restored from a different schema version (file v" + String(r.fileVersion) +
+                      "); applied best-effort. Device restarting now...";
+        }
+    } else {
+        message = r.error;
+    }
+
+    String json = "{";
+    json += "\"status\":\"" + String(r.ok ? "success" : "error") + "\",";
+    json += "\"message\":\"" + escapeJson(message) + "\",";
+    json += "\"applied\":" + String(r.applied) + ",";
+    json += "\"skipped\":" + String(r.skipped) + ",";
+    json += "\"fileVersion\":" + String(r.fileVersion) + ",";
+    json += "\"versionMismatch\":" + String(r.versionMismatch ? "true" : "false");
+    json += "}";
+
+    if (!r.ok) {
+        LOG_WARNING_F("[WebAPI] Configuration restore failed: %s\n", r.error.c_str());
+        sendResponse(400, "application/json", json);
+        return;
+    }
+
+    LOG_INFO_F("[WebAPI] Configuration restore applied (applied: %d, skipped: %d) - rebooting\n", r.applied, r.skipped);
+    sendResponse(200, "application/json", json);
+
+    displayManager.debugPrint("Configuration restored...", COLOR_YELLOW);
+
     delay(500);
     crashLogger.saveBeforeReboot();
     ESP.restart();

--- a/web_config_pages.cpp
+++ b/web_config_pages.cpp
@@ -583,6 +583,47 @@ String WebConfig::generateAdvancedPage() {
             "</script>";
     html += "</div>";
 
+    // Backup and Restore Section
+    html += "<div class='card' style='margin-top:1.5rem'><h2>💾 Backup and Restore</h2>";
+    html += "<p style='color:#94a3b8;margin-bottom:1rem'>Download the full device configuration to a JSON file, or restore a previously saved file. Restoring replaces the current configuration and reboots the device.</p>";
+    html += "<div style='background:rgba(245,158,11,0.1);border:1px solid #f59e0b;border-radius:8px;padding:1rem;margin-bottom:1rem'>";
+    html += "<p style='color:#f59e0b;margin:0;font-size:0.9rem'><i class='fas fa-exclamation-triangle' style='margin-right:8px'></i>If <strong>Include passwords and tokens</strong> is checked, the backup file stores the WiFi password, MQTT password, and Home Assistant token in plaintext.</p>";
+    html += "</div>";
+    html += "<div class='form-group'><label><input type='checkbox' id='backupSecrets'> Include passwords and tokens</label></div>";
+    html += "<div style='display:flex;gap:0.75rem;flex-wrap:wrap;margin-bottom:1.5rem'>";
+    html += "<button type='button' class='btn btn-primary' onclick='downloadBackup()'>⬇️ Download backup</button></div>";
+    html += "<div class='form-group'><label for='restoreFile'>Restore from file</label>";
+    html += "<input type='file' id='restoreFile' accept='.json,application/json' class='form-control'></div>";
+    html += "<div style='display:flex;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.75rem'>";
+    html += "<button type='button' class='btn btn-primary' onclick='restoreBackup()'>♻️ Restore and reboot</button></div>";
+    html += "<div id='backupStatus' style='color:#94a3b8'></div>";
+    html += "<script>"
+            "function downloadBackup(){"
+            "var s=document.getElementById('backupSecrets').checked?'1':'0';"
+            "window.location='/api/backup?secrets='+s;"
+            "}"
+            "function restoreBackup(){"
+            "var st=document.getElementById('backupStatus');"
+            "var fi=document.getElementById('restoreFile');"
+            "if(!fi.files||!fi.files.length){st.textContent='Select a backup file first.';return;}"
+            "if(!confirm('Restore this configuration? The current settings will be replaced and the device will reboot.'))return;"
+            "var rd=new FileReader();"
+            "rd.onload=function(){"
+            "st.textContent='Restoring...';"
+            "fetch('/api/restore',{method:'POST',body:rd.result}).then(function(r){"
+            "return r.json().then(function(j){return {ok:r.ok,body:j};});}).then(function(res){"
+            "var msg=(res.body&&res.body.message)?res.body.message:('HTTP '+(res.body&&res.body.status?res.body.status:'error'));"
+            "if(res.body&&res.body.versionMismatch){msg+=' (backup schema version differs from this firmware; recognized fields were applied on a best-effort basis)';}"
+            "st.textContent=msg;"
+            "if(res.ok){st.textContent=msg+' Device is rebooting...';}"
+            "}).catch(function(e){st.textContent='Restore failed: '+e.message;});"
+            "};"
+            "rd.onerror=function(){st.textContent='Could not read the selected file.';};"
+            "rd.readAsText(fi.files[0]);"
+            "}"
+            "</script>";
+    html += "</div>";
+
     html += "</div></div>";
     return html;
 }


### PR DESCRIPTION
### Features
*   Implemented full device configuration backup and restore, serializing and deserializing config via ArduinoJson.
*   Introduced configuration schema versioning (`CONFIG_SCHEMA_VERSION`) with a `migrate()` hook for future schema changes.
*   Enabled lenient configuration restore: recognized fields are applied (clamped), unknown fields are ignored, and absent fields retain current values.
*   Allowed cross-version restore with a mismatch warning.
*   Ensured secrets (WiFi/MQTT passwords, HA token) are omitted from backups unless explicitly requested and are never erased by a no-secrets restore.
*   Added a Backup and Restore card to the System settings page within the web UI.
*   Created new API endpoints: `GET /api/backup` for downloading backups and `POST /api/restore` for uploading and applying configurations.

### Documentation
*   Added comprehensive design specifications and implementation plans for the config backup/restore feature.
*   Updated the main configuration guide (`docs/03_configuration.md`) to include details on using the new backup/restore feature.
*   Extended the API reference (`docs/developer/api_reference.md`) to document the new backup and restore API endpoints.

### Configuration
*   Added new definitions to `config.h` related to configuration schema versioning.
*   Modified `build_info.h`, likely updating build-related information or version.


---
<sub>Analyzed **3** commit(s) | Updated: 2026-06-15T01:46:55.958Z | Generated by GitHub Actions</sub>